### PR TITLE
Optional input to specify directories to lint/build

### DIFF
--- a/.github/workflows/node-build-and-test.yml
+++ b/.github/workflows/node-build-and-test.yml
@@ -13,6 +13,10 @@ on:
         description: Node Version (such as 20.5)
         default: 'lts/*'
         type: string
+      directories:
+        description: Directories to lint/build (comma separated)
+        default: '.'
+        type: string
       test-timeout:
         description: Time (in minutes) after wich the test job will timeout
         default: 5
@@ -96,7 +100,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-eslint
       - name: Lint
-        run: pnpm lint --cache --cache-location .eslintcache --cache-strategy content
+        run: |
+          FILTERS_ARGUMENTS="${{ inputs.directories }}"
+          if [ -n "$FILTERS_ARGUMENTS" ]; then
+            PNPM_FILTERS="--filter ${FILTERS_ARGUMENTS//,/ --filter }"
+            pnpm $PNPM_FILTERS lint --cache --cache-location .eslintcache --cache-strategy content
+          else
+            pnpm lint --cache --cache-location .eslintcache --cache-strategy content
+          fi
+        shell: bash
   build:
     name: Build Application
     runs-on: ubuntu-latest
@@ -114,7 +126,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run build
-        run: pnpm build:api
+        run: |
+          FILTERS_ARGUMENTS="${{ inputs.directories }}"
+          if [ -n "$FILTERS_ARGUMENTS" ]; then
+            PNPM_FILTERS="--filter ${FILTERS_ARGUMENTS//,/ --filter }"
+            pnpm $PNPM_FILTERS build
+          else
+            pnpm build
+          fi
+        shell: bash
       # Archive
       - name: Store archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/web-build-and-test.yml
+++ b/.github/workflows/web-build-and-test.yml
@@ -13,6 +13,10 @@ on:
         description: Node Version (such as 20.5)
         default: 'lts/*'
         type: string
+      directories:
+        description: Directories to lint/build (comma separated)
+        default: '.'
+        type: string
       test-timeout:
         description: Time (in minutes) after wich the test job will timeout
         default: 5
@@ -45,7 +49,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Lint
-        run: pnpm lint
+        run: |
+          FILTERS_ARGUMENTS="${{ inputs.directories }}"
+          if [ -n "$FILTERS_ARGUMENTS" ]; then
+            PNPM_FILTERS="--filter ${FILTERS_ARGUMENTS//,/ --filter }"
+            pnpm $PNPM_FILTERS lint
+          else
+            pnpm lint
+          fi
+        shell: bash
   typecheck:
     name: Typecheck Application
     runs-on: ubuntu-latest
@@ -86,7 +98,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run build
-        run: pnpm build:web
+        run: |
+          FILTERS_ARGUMENTS="${{ inputs.directories }}"
+          if [ -n "$FILTERS_ARGUMENTS" ]; then
+            PNPM_FILTERS="--filter ${FILTERS_ARGUMENTS//,/ --filter }"
+            pnpm $PNPM_FILTERS build
+          else
+            pnpm build
+          fi
+        shell: bash
       # Archive
       - name: Store archive
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Be able to provide directories to [--filter](https://pnpm.io/filtering) on to build-and-test pipeline of both `node` and `web`.

Can be used by the monorepo as following:
```
name: PR Check Api

on:  # yamllint disable-line rule:truthy
  pull_request:
    types: [opened, synchronize, reopened, ready_for_review]
    branches:
      - main

jobs:
  filter-changes:
    runs-on: ubuntu-latest
    outputs:
      api_changed: ${{ steps.filter.outputs.api_changed }}
      web_changed: ${{ steps.filter.outputs.web_changed }}
    steps:
      - uses: actions/checkout@v4
        with:
          fetch-depth: 0 
          
      - name: Get changed files
        uses: dorny/paths-filter@v3
        id: filter
        with:
          base: ${{ github.base_ref }}
          filters: |
            api_changed:
              - 'apps/api/**'
              - 'packages/api/**'
              - 'packages/shared/**'
            web_changed:
              - 'apps/web/**'
              - 'packages/web/**'
              - 'packages/shared/**'

  api-lint-build-test:
    needs: filter-changes
    if: |
      github.event.pull_request.draft == false && 
      needs.filter-changes.outputs.api_changed == 'true'
    uses: isemen-digital/devops-github-actions/.github/workflows/node-build-and-test.yml@main
    with:
      directories: ./apps/api,./packages/api/*,./packages/shared/*

  web-lint-build-test:
    needs: filter-changes
    if: |
      github.event.pull_request.draft == false && 
      needs.filter-changes.outputs.web_changed == 'true'
    uses: isemen-digital/devops-github-actions/.github/workflows/web-build-and-test.yml@main
    with:
      directories: ./apps/web,./packages/web/*,./packages/shared/*
```