### PR TITLE
add type-check step

### DIFF
--- a/.github/workflows/project-build-and-test.yml
+++ b/.github/workflows/project-build-and-test.yml
@@ -131,7 +131,21 @@ jobs:
           typesense-enabled: ${{ inputs.test-typesense-enabled }}
           typesense-image: ${{ inputs.test-typesense-image }}
 
-  # Then lint & test
+  # Then type check, lint & test
+  type-check:
+    name: Type Check Application
+    needs: [generate-matrix]
+    runs-on: ${{ vars.RUNNER_DEFAULT || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - name: Setup Node environment
+        id: setup
+        uses: wisemen-digital/devops-github-actions/.github/actions/project/setup@v1
+        with:
+          apps: ${{ needs.generate-matrix.outputs.apps }}
+          node-version: ${{ inputs.node-version }}
+      - name: Type check
+        run: pnpm type-check
   lint:
     name: Lint Application
     needs: [generate-matrix]

--- a/.github/workflows/project-build-and-test.yml
+++ b/.github/workflows/project-build-and-test.yml
@@ -242,7 +242,7 @@ jobs:
   # Finally publish test report (summary)
   publish-test-report:
     name: Publish Test Application
-    needs: [check-leaks, lint, test]
+    needs: [check-leaks, lint, test, type-check]
     if: always() && needs.test.result != 'skipped'
     runs-on: ${{ vars.RUNNER_DEFAULT || 'ubuntu-latest' }}
     steps:

--- a/.github/workflows/project-build-and-test.yml
+++ b/.github/workflows/project-build-and-test.yml
@@ -154,7 +154,13 @@ jobs:
           apps: ${{ needs.generate-matrix.outputs.apps }}
           node-version: ${{ inputs.node-version }}
       - name: Type check
-        run: pnpm type-check
+        run: |
+          if test -f 'turbo.json'; then
+            pnpm type-check \
+              ${{ steps.setup.outputs.pnpm-filter-args }}
+          else
+            pnpm --recursive ${{ steps.setup.outputs.pnpm-filter-args }} type-check
+          fi
   lint:
     name: Lint Application
     needs: [generate-matrix]


### PR DESCRIPTION
Run type-check in pipeline to catch typ errors early, avoiding type errors when building the Docker image in later steps (which caused deployment failure)