### PR TITLE
k8s rollout: restart by image (v1)

### DIFF
--- a/.github/actions/docker/setup/action.yml
+++ b/.github/actions/docker/setup/action.yml
@@ -99,13 +99,8 @@ runs:
             ;;
         esac
 
-        # Transform K8S labels
-        if [ -z "${{ inputs.variant-path }}" ]; then
-          echo "k8s_labels=${{ inputs.k8s-labels }}" >> "$GITHUB_OUTPUT"
-        else
-          labels=(${{ inputs.k8s-labels }} variant=${{ inputs.variant-path }})
-          echo "k8s_labels=$(IFS=,;echo "${labels[*]}")" >> "$GITHUB_OUTPUT"
-        fi
+        # K8S rollout labels
+        echo "k8s_labels=${{ inputs.k8s-labels }}" >> "$GITHUB_OUTPUT"
     # Prep. docker environment
     - name: Checkout
       if: ${{ inputs.prepare-for-building == 'true' }}

--- a/.github/actions/infra/k8s/rollout/action.yml
+++ b/.github/actions/infra/k8s/rollout/action.yml
@@ -14,6 +14,9 @@ inputs:
   rollout-labels:
     description: List of labels to rollout (comma separated)
     required: false
+  rollout-image:
+    description: Image reference without tag; restarts deployments running this image
+    required: false
   rollout-namespace:
     description: Rollout namespace filter
     required: true
@@ -79,6 +82,7 @@ runs:
       env:
         DEPLOYMENTS: ${{ inputs.rollout-deployments }}
         LABELS: ${{ inputs.rollout-labels }}
+        IMAGE: ${{ inputs.rollout-image }}
       run: |
         # Restart multiple deployments
         if [ -n "$DEPLOYMENTS" ]; then
@@ -93,6 +97,14 @@ runs:
           kubectl rollout restart deployment \
             --selector="$LABELS" \
             --namespace="${{ inputs.rollout-namespace }}"
+
+        # Restart deployments running the image
+        elif [ -n "$IMAGE" ]; then
+          kubectl get deployment \
+            --namespace="${{ inputs.rollout-namespace }}" -o json \
+            | jq -r --arg img "$IMAGE" '.items[] | select(any(.spec.template.spec.containers[]; .image | startswith($img + ":"))) | .metadata.name' \
+            | xargs -r kubectl rollout restart deployment \
+              --namespace="${{ inputs.rollout-namespace }}"
 
         # Restart everything
         else

--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -163,6 +163,7 @@ jobs:
           cluster-id: ${{ vars.K8S_CLUSTER_ID }}
           rollout-deployments: ${{ vars.K8S_DEPLOYMENTS }}
           rollout-labels: ${{ steps.setup.outputs.k8s-labels }}
+          rollout-image: ${{ steps.setup.outputs.registry }}/${{ steps.setup.outputs.image }}
           rollout-namespace: ${{ vars.K8S_NAMESPACE }}
           # Vendor: azure
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/docker-promote-to-environment.yml
+++ b/.github/workflows/docker-promote-to-environment.yml
@@ -48,6 +48,10 @@ on:
         description: List of variants to roll out (folders in monorepo, separated by commas)
         type: string
         required: false
+      secondary-container-registry:
+        description: Secondary registry namespace to mirror production images to after rollout
+        type: string
+        required: false
     secrets:
       # Vendor: Azure
       AZURE_CLIENT_ID:
@@ -78,6 +82,9 @@ on:
         required: false
       SCALEWAY_SECRET_KEY:
         description: Scaleway API key secret
+        required: false
+      SCALEWAY_SECONDARY_SECRET_KEY:
+        description: Scaleway API key secret for the secondary container registry
         required: false
 
 jobs:
@@ -233,3 +240,26 @@ jobs:
               echo "- Container: \`${{ vars.SERVERLESS_CONTAINER_ID }}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+      - name: Mirror production image to secondary registry
+        if: ${{ needs.validate-and-generate.outputs.target == 'production' && inputs.secondary-container-registry != '' }}
+        shell: bash
+        env:
+          primary_image_ref: ${{ steps.setup.outputs.registry }}/${{ steps.setup.outputs.image }}
+          secondary_registry: ${{ inputs.secondary-container-registry }}
+          secondary_secret_key: ${{ secrets.SCALEWAY_SECONDARY_SECRET_KEY }}
+          target_tag: ${{ needs.validate-and-generate.outputs.target }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${secondary_secret_key}" ]]; then
+            echo "::error title=MISSING SECONDARY REGISTRY CREDENTIALS::SCALEWAY_SECONDARY_SECRET_KEY is required when mirroring production images."
+            exit 1
+          fi
+
+          secondary_registry_host="${secondary_registry%%/*}"
+          printf '%s' "${secondary_secret_key}" | docker login "${secondary_registry_host}" --username nologin --password-stdin
+          trap 'docker logout "${secondary_registry_host}" >/dev/null 2>&1 || true' EXIT
+
+          docker pull "${primary_image_ref}:${target_tag}"
+          docker tag "${primary_image_ref}:${target_tag}" "${secondary_registry}/${{ steps.setup.outputs.image }}:${target_tag}"
+          docker push "${secondary_registry}/${{ steps.setup.outputs.image }}:${target_tag}"

--- a/.github/workflows/docker-promote-to-environment.yml
+++ b/.github/workflows/docker-promote-to-environment.yml
@@ -188,6 +188,7 @@ jobs:
           cluster-id: ${{ vars.K8S_CLUSTER_ID }}
           rollout-deployments: ${{ vars.K8S_DEPLOYMENTS }}
           rollout-labels: ${{ steps.setup.outputs.k8s-labels }}
+          rollout-image: ${{ steps.setup.outputs.registry }}/${{ steps.setup.outputs.image }}
           rollout-namespace: ${{ vars.K8S_NAMESPACE }}
           # Vendor: azure
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/Docs/docker-promote-to-environment.md
+++ b/Docs/docker-promote-to-environment.md
@@ -26,6 +26,7 @@ A redeploy on an existing Serverless Container. It does not create or update the
 | `environment-map` | Custom environment mapping (JSON object) | Yes |
 | `image` | Image name. Defaults to repository name | No |
 | `image-variants` | List of variants to build (folders in monorepo, separated by commas) | No |
+| `secondary-container-registry` | Secondary registry namespace to mirror production images to after rollout | No |
 
 ### Variables & Secrets
 
@@ -86,8 +87,18 @@ Only provide the following for your chosen vendor.
 | `SCALEWAY_PROJECT_ID` | Scaleway project ID (i.e. environment) | Variable | Yes |
 | `SCALEWAY_REGION` | Scaleway region identifier (such as `fr-par`) | Variable | Yes |
 | `SCALEWAY_SECRET_KEY` | Scaleway API key secret | Secret | Yes |
+| `SCALEWAY_SECONDARY_SECRET_KEY` | Scaleway API key secret for the optional secondary production registry | Secret | Required when `secondary-container-registry` is set for production |
 
 </details>
+
+### Secondary production registry
+
+When `environment-target` resolves to `production` and
+`secondary-container-registry` is set, the workflow mirrors each promoted image
+to that registry after the normal rollout. The mirror uses
+`SCALEWAY_SECONDARY_SECRET_KEY` with Scaleway's `nologin` Docker username.
+For example, Ticketgrid mirrors production images to
+`rg.nl-ams.scw.cloud/ticketgrid-registry`.
 
 ## Outputs
 


### PR DESCRIPTION
## What
Restart deployments **by image** on rollout, instead of a synthesized `variant=<folder>` label selector.

- `infra/k8s/rollout`: new `rollout-image` input. Selection priority: `rollout-deployments` → `rollout-labels` → **image (default)** → all. Image mode: `kubectl get deploy -o json | jq (image startswith) | xargs kubectl rollout restart`.
- `docker/setup`: no longer appends `variant=<path>` to the label selector.
- `docker-build-and-deploy` / `docker-promote-to-environment`: pass `rollout-image = <registry>/<image>`.

## Why
The `variant=` selector forced every infra repo to hand-patch a `variant:` label onto its deployments (and one image often backs several deployments). Matching on the just-built image is precise and needs no labels.

## Compatible
`K8S_DEPLOYMENTS` / `K8S_LABELS` still act as overrides. `rollout-image` is derived from the same `setup` output that builds the pushed image, so it matches the deployed image on every branch. Applied identically to main/v1/v2 (verified: image computation is the same on all three; no tags in use).