### PR TITLE
k8s rollout: restart by image (v1)

### DIFF
--- a/.github/actions/docker/setup/action.yml
+++ b/.github/actions/docker/setup/action.yml
@@ -99,13 +99,8 @@ runs:
             ;;
         esac
 
-        # Transform K8S labels
-        if [ -z "${{ inputs.variant-path }}" ]; then
-          echo "k8s_labels=${{ inputs.k8s-labels }}" >> "$GITHUB_OUTPUT"
-        else
-          labels=(${{ inputs.k8s-labels }} variant=${{ inputs.variant-path }})
-          echo "k8s_labels=$(IFS=,;echo "${labels[*]}")" >> "$GITHUB_OUTPUT"
-        fi
+        # K8S rollout labels
+        echo "k8s_labels=${{ inputs.k8s-labels }}" >> "$GITHUB_OUTPUT"
     # Prep. docker environment
     - name: Checkout
       if: ${{ inputs.prepare-for-building == 'true' }}

--- a/.github/actions/infra/k8s/rollout/action.yml
+++ b/.github/actions/infra/k8s/rollout/action.yml
@@ -14,6 +14,9 @@ inputs:
   rollout-labels:
     description: List of labels to rollout (comma separated)
     required: false
+  rollout-image:
+    description: Image reference without tag; restarts deployments running this image
+    required: false
   rollout-namespace:
     description: Rollout namespace filter
     required: true
@@ -79,6 +82,7 @@ runs:
       env:
         DEPLOYMENTS: ${{ inputs.rollout-deployments }}
         LABELS: ${{ inputs.rollout-labels }}
+        IMAGE: ${{ inputs.rollout-image }}
       run: |
         # Restart multiple deployments
         if [ -n "$DEPLOYMENTS" ]; then
@@ -93,6 +97,14 @@ runs:
           kubectl rollout restart deployment \
             --selector="$LABELS" \
             --namespace="${{ inputs.rollout-namespace }}"
+
+        # Restart deployments running the image
+        elif [ -n "$IMAGE" ]; then
+          kubectl get deployment \
+            --namespace="${{ inputs.rollout-namespace }}" -o json \
+            | jq -r --arg img "$IMAGE" '.items[] | select(any(.spec.template.spec.containers[]; .image | startswith($img + ":"))) | .metadata.name' \
+            | xargs -r kubectl rollout restart deployment \
+              --namespace="${{ inputs.rollout-namespace }}"
 
         # Restart everything
         else

--- a/.github/workflows/docker-build-and-deploy.yml
+++ b/.github/workflows/docker-build-and-deploy.yml
@@ -163,6 +163,7 @@ jobs:
           cluster-id: ${{ vars.K8S_CLUSTER_ID }}
           rollout-deployments: ${{ vars.K8S_DEPLOYMENTS }}
           rollout-labels: ${{ steps.setup.outputs.k8s-labels }}
+          rollout-image: ${{ steps.setup.outputs.registry }}/${{ steps.setup.outputs.image }}
           rollout-namespace: ${{ vars.K8S_NAMESPACE }}
           # Vendor: azure
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/.github/workflows/docker-promote-to-environment.yml
+++ b/.github/workflows/docker-promote-to-environment.yml
@@ -181,6 +181,7 @@ jobs:
           cluster-id: ${{ vars.K8S_CLUSTER_ID }}
           rollout-deployments: ${{ vars.K8S_DEPLOYMENTS }}
           rollout-labels: ${{ steps.setup.outputs.k8s-labels }}
+          rollout-image: ${{ steps.setup.outputs.registry }}/${{ steps.setup.outputs.image }}
           rollout-namespace: ${{ vars.K8S_NAMESPACE }}
           # Vendor: azure
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
## What
Restart deployments by image on rollout (priority: `rollout-deployments` → `rollout-labels` → **image (default)** → all), instead of the `variant=<folder>` label selector.

- `infra/k8s/rollout`: new `rollout-image` input + image-match step.
- `docker/setup`: no longer appends `variant=<path>` to the label selector.
- `docker-build-and-deploy` / `docker-promote-to-environment`: pass `rollout-image = <registry>/<image>`.

## Why
Removes the need to hand-patch a `variant:` label onto every deployment; one image often backs several deployments. Backward compatible (`K8S_DEPLOYMENTS`/`K8S_LABELS` still override).

_(Recreated on the untangled v1/v2 after the accidental cross-merge was reverted.)_