### PR TITLE
infra-k8s-preview: no-op when no k8s paths changed

### DIFF
--- a/.github/workflows/infra-k8s-preview.yml
+++ b/.github/workflows/infra-k8s-preview.yml
@@ -38,8 +38,14 @@ jobs:
         run: |
           changed_paths=`echo $matrix | jq -r '.[].path'`
 
+          if [ -z "$changed_paths" ]; then
+            echo "No changed k8s paths; nothing to preview."
+            exit 0
+          fi
+
           # Generate new content
           while IFS= read -r path; do
+            [ -z "$path" ] && continue
             echo "Processing new $path…"
             mkdir -p `dirname diff-new/$path`
             if [ -e "$path" ]; then
@@ -57,6 +63,7 @@ jobs:
 
           # Generate old content
           while IFS= read -r path; do
+            [ -z "$path" ] && continue
             echo "Processing old $path…"
             mkdir -p `dirname diff-old/$path`
             if [ -e "$path" ]; then
@@ -71,6 +78,7 @@ jobs:
           {
             echo 'contents<<EOF'
             while IFS= read -r path; do
+              [ -z "$path" ] && continue
               echo "<details><summary>$path</summary>"
               echo -e '\n```diff'
               diff -u "diff-old/$path" "diff-new/$path" || true


### PR DESCRIPTION
**Fixes the mass CI failures on infra workflow-only PRs.**

`infra-k8s-preview`'s diff step runs `while IFS= read -r path; do … done <<< "$changed_paths"`. When `changed_paths` is empty (PR touches no `k8s/**`), the here-string still yields **one empty iteration**, so `touch "diff-new/$path"` runs as `touch "diff-new/"` → *No such file or directory* → job fails.

Any PR that changes no k8s paths fails the preview (the CI-migration PRs, docs-only PRs, …).

Fix: early-exit when no changed paths + skip empty paths defensively. **Should also go to v2 and main** (same file/bug).