### PR TITLE
infra-k8s-preview: no-op when no k8s paths changed (main)

### DIFF
--- a/.github/workflows/infra-k8s-preview.yml
+++ b/.github/workflows/infra-k8s-preview.yml
@@ -36,8 +36,14 @@ jobs:
         run: |
           changed_paths=`echo $matrix | jq -r '.[].path'`
 
+          if [ -z "$changed_paths" ]; then
+            echo "No changed k8s paths; nothing to preview."
+            exit 0
+          fi
+
           # Generate new content
           while IFS= read -r path; do
+            [ -z "$path" ] && continue
             echo "Processing new $path…"
             mkdir -p `dirname diff-new/$path`
             if [ -e "$path" ]; then
@@ -55,6 +61,7 @@ jobs:
 
           # Generate old content
           while IFS= read -r path; do
+            [ -z "$path" ] && continue
             echo "Processing old $path…"
             mkdir -p `dirname diff-old/$path`
             if [ -e "$path" ]; then
@@ -69,6 +76,7 @@ jobs:
           {
             echo 'contents<<EOF'
             while IFS= read -r path; do
+              [ -z "$path" ] && continue
               echo "<details><summary>$path</summary>"
               echo -e '\n```diff'
               diff -u "diff-old/$path" "diff-new/$path" || true


### PR DESCRIPTION
Same fix as #49 (into `main`): guard the preview diff loop against empty changed_paths so PRs touching no `k8s/**` don't fail with `touch diff-new/: No such file or directory`.